### PR TITLE
#1096: Adds livestream.com, channel9.msdn.com embed domains

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.4
+sbt.version = 1.1.6

--- a/src/main/resources/embed-tag-rules.json
+++ b/src/main/resources/embed-tag-rules.json
@@ -93,7 +93,6 @@
       ],
       "validSrcDomains": [
         "prezi.com",
-        "www.commoncraft.com",
         "ndla.filmiundervisning.no",
         "embed.kahoot.it",
         ".*.khanacademy.org",
@@ -101,7 +100,9 @@
         "tv2skole.no",
         ".*.tv2skole.no",
         "www.scribd.com",
-        "www.vg.no"
+        "www.vg.no",
+        "livestream.com",
+        ".*.livestream.com"
       ]
     },
     "footnote": {

--- a/src/main/resources/embed-tag-rules.json
+++ b/src/main/resources/embed-tag-rules.json
@@ -102,7 +102,8 @@
         "www.scribd.com",
         "www.vg.no",
         "livestream.com",
-        ".*.livestream.com"
+        ".*.livestream.com",
+        "channel9.msdn.com"
       ]
     },
     "footnote": {


### PR DESCRIPTION
connects to https://github.com/NDLANO/Issues/issues/1096