### PR TITLE
Add data tag for inline render to file

### DIFF
--- a/src/main/resources/embed-tag-rules.json
+++ b/src/main/resources/embed-tag-rules.json
@@ -185,7 +185,8 @@
       ],
       "optional": [
         [ "data-type" ],
-        [ "data-alt" ]
+        [ "data-alt" ],
+        [ "data-render-inline" ]
       ],
       "mustBeDirectChildOf": {
         "name": "div",

--- a/src/main/scala/no/ndla/validation/TagRules.scala
+++ b/src/main/scala/no/ndla/validation/TagRules.scala
@@ -74,6 +74,7 @@ object TagAttributes extends Enumeration {
   val DataPath = Value("data-path")
   val DataFormat = Value("data-code-format")
   val DataContent = Value("data-code-content")
+  val DataRenderInline = Value("data-render-inline")
 
   val DataUpperLeftY = Value("data-upper-left-y")
   val DataUpperLeftX = Value("data-upper-left-x")


### PR DESCRIPTION
Tilhører NDLANO/Issues#2410

Legger data attributt til fil-embed. Denne skal brukes til å bestemme om en fil (spesifikt pdf) skal vises inline i en artikkel eller ikke.