### PR TITLE
Add support for ndla.no domains.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip awscliv2.zip
-          sudo ./aws/install
+          sudo ./aws/install --update
       - name: "Login to ECR repo"
         run: RES=$(aws sts assume-role --role-arn arn:aws:iam::950645517739:role/releaseAccess --role-session-name travis-test-release-pull-whatever)
           AWS_ACCESS_KEY_ID=$(echo $RES | jq -r .Credentials.AccessKeyId)

--- a/src/main/resources/embed-tag-rules.json
+++ b/src/main/resources/embed-tag-rules.json
@@ -102,6 +102,7 @@
         "data-height"
       ],
       "validSrcDomains": [
+        ".*.ndla.no",
         "vimeo.com",
         "ndla.filmiundervisning.no",
         "prezi.com",

--- a/src/test/scala/no/ndla/validation/EmbedTagValidatorTest.scala
+++ b/src/test/scala/no/ndla/validation/EmbedTagValidatorTest.scala
@@ -294,9 +294,19 @@ class EmbedTagValidatorTest extends UnitSuite {
         TagAttributes.DataUrl -> "https://prezi.com",
         TagAttributes.DataWidth -> "1",
         TagAttributes.DataHeight -> "1"
-      ))
-
+      )
+    )
     embedTagValidator.validate("content", tag).size should be(0)
+
+    val tag2 = generateTagWithAttrs(
+      Map(
+        TagAttributes.DataResource -> ResourceType.IframeContent.toString,
+        TagAttributes.DataUrl -> "https://statisk.test.ndla.no",
+        TagAttributes.DataWidth -> "1",
+        TagAttributes.DataHeight -> "1"
+      )
+    )
+    embedTagValidator.validate("content", tag2).size should be(0)
   }
 
   test("validate should fail if source url is from an illlegal domain") {


### PR DESCRIPTION
Legger til støtte for å lagre ndla.no domener i iframe. Skal brukes for å kunne vise fram statisk.ndla.no i iframe uten å måtte gå via h5p-iframe.