### PR TITLE
Make text in concept embed optional

### DIFF
--- a/src/main/resources/embed-tag-rules.json
+++ b/src/main/resources/embed-tag-rules.json
@@ -90,8 +90,10 @@
       "required": [
         "data-resource",
         "data-content-id",
-        "data-link-text",
         "data-type"
+      ],
+      "optional": [
+        "data-link-text",
       ]
     },
     "iframe": {


### PR DESCRIPTION
Relater til NDLANO/Issues#3016

Tekst er ikke relevant for blokkvisning av forklaring og burde derfor være optional